### PR TITLE
Add product content type

### DIFF
--- a/data/product.xml
+++ b/data/product.xml
@@ -15,6 +15,7 @@
     <IDValue>9780194351898</IDValue>
   </ProductIdentifier>
   <ProductForm>BC</ProductForm>
+  <ProductContentType>01</ProductContentType>
   <Series>
     <TitleOfSeries>DICTIONARIES BEGINNER TO PRE-INTERMED</TitleOfSeries>
   </Series>

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -11,6 +11,7 @@ module ONIX
     xml_accessor :product_identifiers, :from => "ProductIdentifier", :as => [ONIX::ProductIdentifier]
     xml_accessor :product_form, :from => "ProductForm"
     xml_accessor :product_form_detail, :from => "ProductFormDetail"
+    xml_accessor :product_content_type, :from => "ProductContentType"
     xml_accessor :series, :from => "Series", :as => [ONIX::Series]
     xml_accessor :titles, :from => "Title", :as => [ONIX::Title]
     xml_accessor :websites, :from => "Website", :as => [ONIX::Website]

--- a/spec/normaliser_spec.rb
+++ b/spec/normaliser_spec.rb
@@ -19,12 +19,8 @@ describe ONIX::Normaliser, "with a simple short tag file" do
 
     File.file?(@outfile).should be_true
     content = File.read(@outfile)
-    puts "content: ", content
     content.include?("<m174>").should be_false
     content.include?("<FromCompany>").should be_true
-
-    content.include?("<m185>").should be false
-    content.include?("<ProductContentType>").should be true
   end
 end
 

--- a/spec/normaliser_spec.rb
+++ b/spec/normaliser_spec.rb
@@ -19,8 +19,12 @@ describe ONIX::Normaliser, "with a simple short tag file" do
 
     File.file?(@outfile).should be_true
     content = File.read(@outfile)
+    puts "content: ", content
     content.include?("<m174>").should be_false
     content.include?("<FromCompany>").should be_true
+
+    content.include?("<m185>").should be false
+    content.include?("<ProductContentType>").should be true
   end
 end
 

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -23,6 +23,7 @@ describe ONIX::Product do
     product.publishing_status.should eql(4)
     product.publication_date.should eql(Date.civil(1998,9,1))
     product.year_first_published.should eql(1998)
+    product.product_content_type.should eql(01)
 
     # including ye olde, deprecated ones
     product.height.should eql(100)
@@ -50,6 +51,11 @@ describe ONIX::Product do
   it "should provide read access to measurements" do
     product = ONIX::Product.from_xml(@product_node.to_s)
     product.measurements.size.should eql(1)
+  end
+
+  it "should provide read access to product content types" do
+    product = ONIX::Product.from_xml(@product_node.to_s)
+    product.product_content_type.should eql(01)
   end
 
   it "should provide write access to first level attributes" do

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -23,7 +23,7 @@ describe ONIX::Product do
     product.publishing_status.should eql(4)
     product.publication_date.should eql(Date.civil(1998,9,1))
     product.year_first_published.should eql(1998)
-    product.product_content_type.should eql(01)
+    product.product_content_type.should eql("01")
 
     # including ye olde, deprecated ones
     product.height.should eql(100)
@@ -55,7 +55,7 @@ describe ONIX::Product do
 
   it "should provide read access to product content types" do
     product = ONIX::Product.from_xml(@product_node.to_s)
-    product.product_content_type.should eql(01)
+    product.product_content_type.should eql("01")
   end
 
   it "should provide write access to first level attributes" do


### PR DESCRIPTION
We're adding Harper Collins as a data provider for pulp. Their data dump includes audiobooks as well as ebooks, so we'll need to filter them out (unless and until we decide to add support for audiobooks). Audiobooks are specified as a product content type in onix format, so we need to look at this field and pass it on to callers so that pulp can use it to filter out some books.

I didn't make changes to the normaliser spec (or any other tests) because those tests fail locally for me. However, I've added some testing on the pulp side for the normaliser that'll blow up if a) the normaliser isn't working, and b) the changes I'm making in this PR aren't working. 