### PR TITLE
Replace references to Fixnum with Integer for ruby 2.4+

### DIFF
--- a/lib/onix/addressee_identifier.rb
+++ b/lib/onix/addressee_identifier.rb
@@ -4,7 +4,7 @@ module ONIX
   class AddresseeIdentifier
     include ROXML
 
-    xml_accessor :addressee_id_type, :from => "AddresseeIDType", :as => Fixnum # should be a 2 digit num
+    xml_accessor :addressee_id_type, :from => "AddresseeIDType", :as => Integer # should be a 2 digit num
     xml_accessor :id_type_name,      :from => "IDTypeName"
     xml_accessor :id_value,          :from => "IDValue"
   end

--- a/lib/onix/audience_range.rb
+++ b/lib/onix/audience_range.rb
@@ -6,8 +6,8 @@ module ONIX
 
     xml_name "AudienceRange"
 
-    xml_accessor :audience_range_qualifier, :from => "AudienceRangeQualifier", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :audience_range_precisions, :from => "AudienceRangePrecision", :as => [Fixnum], :to_xml => [ONIX::Formatters.two_digit] # TODO: two_digit isn't working on the array items
+    xml_accessor :audience_range_qualifier, :from => "AudienceRangeQualifier", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :audience_range_precisions, :from => "AudienceRangePrecision", :as => [Integer], :to_xml => [ONIX::Formatters.two_digit] # TODO: two_digit isn't working on the array items
     xml_accessor :audience_range_values, :from => "AudienceRangeValue"
 
     # TODO: element AudienceRange: validity error :

--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -6,10 +6,10 @@ module ONIX
 
     xml_name "Contributor"
 
-    xml_accessor :sequence_number,             :from => "SequenceNumber", :as => Fixnum
+    xml_accessor :sequence_number,             :from => "SequenceNumber", :as => Integer
     xml_accessor :contributor_role,            :from => "ContributorRole"
     xml_accessor :language_code,               :from => "LanguageCode"
-    xml_accessor :sequence_number_within_role, :from => "SequenceNumberWithinRole", :as => Fixnum
+    xml_accessor :sequence_number_within_role, :from => "SequenceNumberWithinRole", :as => Integer
     xml_accessor :person_name,                 :from => "PersonName"
     xml_accessor :person_name_inverted,        :from => "PersonNameInverted"
     xml_accessor :titles_before_names,         :from => "TitlesBeforeNames"
@@ -23,7 +23,7 @@ module ONIX
     xml_accessor :corporate_name,              :from => "CorporateName"
     xml_accessor :biographical_note,           :from => "BiographicalNote"
     xml_accessor :contributor_description,     :from => "ContributorDescription"
-    xml_accessor :unnamed_persons,             :from => "UnnamedPersons", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :unnamed_persons,             :from => "UnnamedPersons", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :country_code,                :from => "CountryCode"
     xml_accessor :region_code,                 :from => "RegionCode"
     xml_accessor :person_name_identifiers,     :from => "PersonNameIdentifier", :as => [ONIX::PersonNameIdentifier]

--- a/lib/onix/discount_coded.rb
+++ b/lib/onix/discount_coded.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "DiscountCoded"
 
-    xml_accessor :discount_code_type, :from => "DiscountCodeType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :discount_code_type, :from => "DiscountCodeType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :discount_code_type_name, :from => "DiscountCodeTypeName"
     xml_accessor :discount_code, :from => "DiscountCode"
   end

--- a/lib/onix/header.rb
+++ b/lib/onix/header.rb
@@ -18,7 +18,7 @@ module ONIX
     xml_accessor :to_company,      :from => "ToCompany"
     xml_accessor :to_person,       :from => "ToPerson"
     xml_accessor :message_number,  :from => "MessageNumber"
-    xml_accessor :message_repeat,  :from => "MessageRepeat", :as => Fixnum
+    xml_accessor :message_repeat,  :from => "MessageRepeat", :as => Integer
     xml_accessor(:sent_date,       :from => "SentDate", :to_xml => ONIX::Formatters.yyyymmdd) do |val|
       begin
         Date.parse(val)
@@ -30,7 +30,7 @@ module ONIX
 
     # defaults
     xml_accessor  :default_language_of_text, :from => "DefaultLanguageOfText"
-    xml_accessor  :default_price_type_code, :from => "DefaultPriceTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor  :default_price_type_code, :from => "DefaultPriceTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor  :default_currency_code,   :from => "DefaultCurrencyCode"
     xml_reader    :default_linear_unit,     :from => "DefaultLinearUnit"        # deprecated in ONIX spec
     xml_reader    :default_weight_unit,     :from => "DefaultWeightUnit"        # deprecated in ONIX spec

--- a/lib/onix/imprint.rb
+++ b/lib/onix/imprint.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Imprint"
 
-    xml_accessor :name_code_type,      :from => "NameCodeType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :name_code_type,      :from => "NameCodeType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :name_code_type_name, :from => "NameCodeTypeName"
     xml_accessor :name_code_value,     :from => "NameCodeValue"
     xml_accessor :imprint_name,        :from => "ImprintName"

--- a/lib/onix/language.rb
+++ b/lib/onix/language.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Language"
 
-    xml_accessor :language_role,        :from => "LanguageRole", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :language_role,        :from => "LanguageRole", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :language_code,        :from => "LanguageCode"
     xml_accessor :country_code,         :from => "CountryCode"
   end

--- a/lib/onix/lists.rb
+++ b/lib/onix/lists.rb
@@ -82,7 +82,7 @@ module ONIX
 
     # return a hash with the data for a single code list.
     #
-    # number should be a fixnum specifying the list to retrieve
+    # number should be a Integer specifying the list to retrieve
     #
     #  ONIX::Lists.instance.list(7)
     #  => { "BB" => "Hardback", ... }

--- a/lib/onix/market_representation.rb
+++ b/lib/onix/market_representation.rb
@@ -7,12 +7,12 @@ module ONIX
     xml_name "MarketRepresentation"
 
     xml_accessor :agent_name, :from => "AgentName"
-    xml_accessor :agent_role, :from => "AgentRole", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :agent_role, :from => "AgentRole", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :market_country, :from => "MarketCountry"
     xml_accessor :market_territory, :from => "MarketTerritory"
     xml_accessor :market_country_excluded, :from => "MarketCountryExcluded"
     xml_accessor :market_restriction_detail, :from => "MarketRestrictionDetail"
-    xml_accessor :market_publishing_status, :from => "MarketPublishingStatus", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :market_publishing_status, :from => "MarketPublishingStatus", :as => Integer, :to_xml => ONIX::Formatters.two_digit
   end
 end
 

--- a/lib/onix/measure.rb
+++ b/lib/onix/measure.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Measure"
 
-    xml_accessor :measure_type_code, :from => "MeasureTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :measure_type_code, :from => "MeasureTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :measurement,       :from => "Measurement", :as => BigDecimal
     xml_accessor :measure_unit_code, :from => "MeasureUnitCode"
   end

--- a/lib/onix/media_file.rb
+++ b/lib/onix/media_file.rb
@@ -6,10 +6,10 @@ module ONIX
 
     xml_name "MediaFile"
 
-    xml_accessor :media_file_type_code, :from => "MediaFileTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :media_file_format_code, :from => "MediaFileFormatCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :media_file_type_code, :from => "MediaFileTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :media_file_format_code, :from => "MediaFileFormatCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :image_resolution, :from => "ImageResolution"
-    xml_accessor :media_file_link_type_code, :from => "MediaFileLinkTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :media_file_link_type_code, :from => "MediaFileLinkTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :media_file_link, :from => "MediaFileLink"
   end
 end

--- a/lib/onix/name.rb
+++ b/lib/onix/name.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Name"
 
-    xml_accessor :person_name_type,        :from => "PersonNameType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :person_name_type,        :from => "PersonNameType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :person_name,             :from => "PersonName"
     xml_accessor :person_name_inverted,    :from => "PersonNameInverted"
     xml_accessor :titles_before_names,     :from => "TitlesBeforeNames"

--- a/lib/onix/other_text.rb
+++ b/lib/onix/other_text.rb
@@ -6,10 +6,10 @@ module ONIX
 
     xml_name "OtherText"
 
-    xml_accessor :text_type_code, :from => "TextTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :text_type_code, :from => "TextTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :text_format,    :from => "TextFormat"
     xml_accessor :text,           :from => "Text"
-    xml_accessor :text_link_type, :from => "TextLinkType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :text_link_type, :from => "TextLinkType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :text_link,      :from => "TextLink"
     xml_accessor :text_author,    :from => "TextAuthor"
   end

--- a/lib/onix/person_date.rb
+++ b/lib/onix/person_date.rb
@@ -6,8 +6,8 @@ module ONIX
 
     xml_name "PersonDate"
 
-    xml_accessor :person_date_role, :from => "PersonDateRole", :as => Fixnum
-    xml_accessor :date_format,      :from => "DateFormat", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :person_date_role, :from => "PersonDateRole", :as => Integer
+    xml_accessor :date_format,      :from => "DateFormat", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :date,             :from => "Date"
   end
 end

--- a/lib/onix/person_name_identifier.rb
+++ b/lib/onix/person_name_identifier.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "PersonNameIdentifier"
 
-    xml_accessor :person_name_id_type, :from => "PersonNameIDType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :person_name_id_type, :from => "PersonNameIDType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :id_type_name,        :from => "IDTypeName"
     xml_accessor :id_value,            :from => "IDValue"
   end

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -6,15 +6,15 @@ module ONIX
 
     xml_name "Price"
 
-    xml_accessor :price_type_code, :from => "PriceTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :price_type_qualifier, :from => "PriceQualifier", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :price_type_code, :from => "PriceTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :price_type_qualifier, :from => "PriceQualifier", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :price_type_description, :from => "PriceTypeDescription"
-    xml_accessor :price_per, :from => "PricePer", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :minimum_order_qty, :from => "MinimumOrderQuantity", :as => Fixnum
+    xml_accessor :price_per, :from => "PricePer", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :minimum_order_qty, :from => "MinimumOrderQuantity", :as => Integer
     xml_accessor :class_of_trade, :from => "ClassOfTrade"
     xml_accessor :bic_discount_group_code, :from => "BICDiscountGroupCode"
     xml_accessor :discounts_coded, :from => "DiscountCoded", :as => [ONIX::DiscountCoded]
-    xml_accessor :price_status, :from => "PriceStatus", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :price_status, :from => "PriceStatus", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :price_amount, :from => "PriceAmount", :as => BigDecimal, :to_xml => ONIX::Formatters.decimal
     xml_accessor :currency_code, :from => "CurrencyCode"
 

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -7,7 +7,7 @@ module ONIX
     xml_name "Product"
 
     xml_accessor :record_reference, :from => "RecordReference"
-    xml_accessor :notification_type, :from => "NotificationType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :notification_type, :from => "NotificationType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :product_identifiers, :from => "ProductIdentifier", :as => [ONIX::ProductIdentifier]
     xml_accessor :product_form, :from => "ProductForm"
     xml_accessor :product_form_detail, :from => "ProductFormDetail"
@@ -16,9 +16,9 @@ module ONIX
     xml_accessor :titles, :from => "Title", :as => [ONIX::Title]
     xml_accessor :websites, :from => "Website", :as => [ONIX::Website]
     xml_accessor :contributors, :from => "Contributor", :as => [ONIX::Contributor]
-    xml_accessor :edition_number, :from => "EditionNumber", :as => Fixnum
+    xml_accessor :edition_number, :from => "EditionNumber", :as => Integer
     xml_accessor :languages, :from => "Language", :as => [ONIX::Language]
-    xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Fixnum
+    xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Integer
     xml_accessor :basic_main_subject, :from => "BASICMainSubject"
     xml_accessor :bic_main_subject, :from => "BICMainSubject"
     xml_accessor :subjects, :from => "Subject", :as => [ONIX::Subject]
@@ -28,7 +28,7 @@ module ONIX
     xml_accessor :media_files, :from => "MediaFile", :as => [ONIX::MediaFile]
     xml_accessor :imprints, :from => "Imprint", :as => [ONIX::Imprint]
     xml_accessor :publishers, :from => "Publisher", :as => [ONIX::Publisher]
-    xml_accessor :publishing_status, :from => "PublishingStatus", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :publishing_status, :from => "PublishingStatus", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor(:publication_date, :from => "PublicationDate", :to_xml => ONIX::Formatters.yyyymmdd) do |val|
       begin
         Date.parse(val)
@@ -37,7 +37,7 @@ module ONIX
       end
     end
     xml_accessor :copyright_year, :from => "CopyrightYear", :as => Integer
-    xml_accessor :year_first_published, :from => "YearFirstPublished", :as => Fixnum
+    xml_accessor :year_first_published, :from => "YearFirstPublished", :as => Integer
     xml_accessor :sales_restrictions, :from => "SalesRestriction", :as => [ONIX::SalesRestriction]
     xml_accessor :measurements, :from => "Measure", :as => [ONIX::Measure]
     xml_accessor :supply_details, :from => "SupplyDetail", :as => [ONIX::SupplyDetail]

--- a/lib/onix/product_identifier.rb
+++ b/lib/onix/product_identifier.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "ProductIdentifier"
 
-    xml_accessor :product_id_type, :from => "ProductIDType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :product_id_type, :from => "ProductIDType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :id_value, :from => "IDValue"
   end
 end

--- a/lib/onix/publisher.rb
+++ b/lib/onix/publisher.rb
@@ -6,8 +6,8 @@ module ONIX
 
     xml_name "Publisher"
 
-    xml_accessor :publishing_role,      :from => "PublishingRole", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :name_code_type,       :from => "NameCodeType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :publishing_role,      :from => "PublishingRole", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :name_code_type,       :from => "NameCodeType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :name_code_type_name,  :from => "NameCodeTypeName"
     xml_accessor :name_code_type_value, :from => "NameCodeTypeValue"
     xml_accessor :publisher_name,       :from => "PublisherName"

--- a/lib/onix/sales_restriction.rb
+++ b/lib/onix/sales_restriction.rb
@@ -6,6 +6,6 @@ module ONIX
 
     xml_name "SalesRestriction"
 
-    xml_accessor :sales_restriction_type, :from =>"SalesRestrictionType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :sales_restriction_type, :from =>"SalesRestrictionType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
   end
 end

--- a/lib/onix/sender_identifier.rb
+++ b/lib/onix/sender_identifier.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "SenderIdentifier"
 
-    xml_accessor :sender_id_type, :from => "SenderIDType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :sender_id_type, :from => "SenderIDType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :id_type_name,   :from => "IDTypeName"
     xml_accessor :id_value,       :from => "IDValue"
   end

--- a/lib/onix/series_identifier.rb
+++ b/lib/onix/series_identifier.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "SeriesIdentifier"
 
-    xml_accessor :series_id_type, :from => "SeriesIDType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :series_id_type, :from => "SeriesIDType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :id_value, :from => "IDValue"
   end
 end

--- a/lib/onix/subject.rb
+++ b/lib/onix/subject.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Subject"
 
-    xml_accessor :subject_scheme_id,      :from => "SubjectSchemeIdentifier", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :subject_scheme_id,      :from => "SubjectSchemeIdentifier", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :subject_scheme_name,    :from => "SubjectSchemeName"
     xml_accessor :subject_scheme_version, :from => "SubjectSchemeVersion"
     xml_accessor :subject_code,           :from => "SubjectCode"

--- a/lib/onix/supply_detail.rb
+++ b/lib/onix/supply_detail.rb
@@ -13,13 +13,13 @@ module ONIX
     xml_accessor :fax_number, :from => "FaxNumber"
     xml_accessor :email_address, :from => "EmailAddress"
     xml_accessor :websites, :from => "Website", :as => [ONIX::Website]
-    xml_accessor :supplier_role, :from => "SupplierRole", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :supplier_role, :from => "SupplierRole", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :supply_to_country, :from => "SupplyToCountry"
     xml_accessor :supply_to_territory, :from => "SupplyToTerritory"
-    xml_accessor :availability_status_code, :from => "AvailabilityStatusCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
-    xml_accessor :product_availability, :from => "ProductAvailability", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :availability_status_code, :from => "AvailabilityStatusCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :product_availability, :from => "ProductAvailability", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :stock, :from => "Stock", :as => [ONIX::Stock]
-    xml_accessor :pack_quantity, :from => "PackQuantity", :as => Fixnum
+    xml_accessor :pack_quantity, :from => "PackQuantity", :as => Integer
     xml_accessor :prices, :from => "Price", :as => [ONIX::Price]
 
     def initialize

--- a/lib/onix/title.rb
+++ b/lib/onix/title.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Title"
 
-    xml_accessor :title_type, :from => "TitleType", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :title_type, :from => "TitleType", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :title_text, :from => "TitleText"
     xml_accessor :title_prefix, :from => "TitlePrefix"
     xml_accessor :title_without_prefix, :from => "TitleWithoutPrefix"

--- a/lib/onix/website.rb
+++ b/lib/onix/website.rb
@@ -6,7 +6,7 @@ module ONIX
 
     xml_name "Website"
 
-    xml_accessor :website_role,        :from => "WebsiteRole", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor :website_role,        :from => "WebsiteRole", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :website_description, :from => "WebsiteDescription"
     xml_accessor :website_link,        :from => "WebsiteLink"
   end

--- a/onix.gemspec
+++ b/onix.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob("spec/**/*.rb")
   s.files             = Dir.glob("{lib,support,dtd}/**/**/*") + ["README.markdown", "TODO", "CHANGELOG"]
 
-  s.add_dependency('roxml', '~>3.3.1')
+  s.add_dependency('roxml', '~>4.0.0')
   s.add_dependency('activesupport', '>= 3.0.5')
   s.add_dependency('i18n')
   s.add_dependency('andand')


### PR DESCRIPTION
Fixnum was deprecated in Ruby 2.4, and was rolled up into the Integer class:
https://bugs.ruby-lang.org/issues/12005

This will allow us to upgrade Pulp's ruby version without running into a slew of deprecation warnings every time we boot the application.

* replaces references to Fixnum with Integer

* bumps the `roxml` gem to 4.0.0 to pick up changes that remove references to Fixnum/Bignum.

**Note on specs:** Based on what's in Circle and the recent PRs that were merged to this gem fork, I don't think specs were ever running/configured to run for this project — not sure if it's worth a pass to get them working.