### PR TITLE
Fix BigDecimal error in Ruby 2.7..

### DIFF
--- a/lib/onix/reader.rb
+++ b/lib/onix/reader.rb
@@ -128,7 +128,7 @@ module ONIX
         if @reader.node_type == 1 && @reader.name == "ONIXMessage"
           value = @reader.attributes["release"]
           if value
-            return BigDecimal.new(value)
+            return BigDecimal(value)
           else
             return nil
           end

--- a/onix.gemspec
+++ b/onix.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob("spec/**/*.rb")
   s.files             = Dir.glob("{lib,support,dtd}/**/**/*") + ["README.markdown", "TODO", "CHANGELOG"]
 
-  s.add_dependency('roxml', '~>4.0.0')
+  s.add_dependency('roxml', '~>4.2.0')
   s.add_dependency('activesupport', '>= 3.0.5')
   s.add_dependency('i18n')
   s.add_dependency('andand')

--- a/spec/apa_product_spec.rb
+++ b/spec/apa_product_spec.rb
@@ -78,7 +78,7 @@ describe ONIX::APAProduct, "price method" do
     @product = ONIX::Product.from_xml(@product_node.to_s)
     @apa     = ONIX::APAProduct.new(@product)
 
-    @apa.price.should eql(BigDecimal.new("99.95"))
+    @apa.price.should eql(BigDecimal("99.95"))
   end
 end
 
@@ -94,7 +94,7 @@ describe ONIX::APAProduct, "rrp_exc_sales_tax method" do
     @product = ONIX::Product.from_xml(@product_node.to_s)
     @apa     = ONIX::APAProduct.new(@product)
 
-    @apa.rrp_exc_sales_tax.should eql(BigDecimal.new("99.95"))
+    @apa.rrp_exc_sales_tax.should eql(BigDecimal("99.95"))
   end
 end
 

--- a/spec/price_spec.rb
+++ b/spec/price_spec.rb
@@ -20,7 +20,7 @@ describe ONIX::Price do
     p = ONIX::Price.from_xml(@root.to_s)
 
     p.price_type_code.should eql(2)
-    p.price_amount.should eql(BigDecimal.new("7.5"))
+    p.price_amount.should eql(BigDecimal("7.5"))
   end
 
   it "should provide write access to first level attributes" do
@@ -29,7 +29,7 @@ describe ONIX::Price do
     p.price_type_code = 1
     p.to_xml.to_s.include?("<PriceTypeCode>01</PriceTypeCode>").should be_true
 
-    p.price_amount = BigDecimal.new("7.5")
+    p.price_amount = BigDecimal("7.5")
     p.to_xml.to_s.include?("<PriceAmount>7.5</PriceAmount>").should be_true
 
   end

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -27,7 +27,7 @@ describe ONIX::Product do
 
     # including ye olde, deprecated ones
     product.height.should eql(100)
-    product.width.should eql(BigDecimal.new("200.5"))
+    product.width.should eql(BigDecimal("200.5"))
     product.weight.should eql(300)
     product.thickness.should eql(300)
     product.dimensions.should eql("100x200")

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -30,7 +30,7 @@ describe ONIX::Reader do
   it "should provide access to various XML metadata from file" do
     filename = File.join(@data_path, "reference_with_release_attrib.xml")
     reader = ONIX::Reader.new(filename)
-    reader.release.should eql(BigDecimal.new("2.1"))
+    reader.release.should eql(BigDecimal("2.1"))
   end
 
   it "should provide access to the header in an ONIX file" do


### PR DESCRIPTION
While working on[ upgrading Pulp to Ruby 2.7](https://github.com/BookBub/pulp/pull/2263), we noticed an error related to BigDecimal. Ruby 2.7 has moved away from `BigDecimal.new(value)` to `BigDecimal(value)` and was causing errors. Also updated roxml to the latest version (which also fixes the BigDecimal issue). 