### PR TITLE
Adds `dtdload` option for DTD schema handling

### DIFF
--- a/lib/onix/reader.rb
+++ b/lib/onix/reader.rb
@@ -80,6 +80,8 @@ module ONIX
 
     def initialize(input, *args)
       opts = args.last.kind_of?(Hash) ? args.pop : {}
+      opts = opts.reverse_merge(dtdload: true)
+
       if args.size > 0
         ActiveSupport::Deprecation.warn("Passing a klass as ONIX::Reader's second argument is deprecated, use the :product_class option instead", caller)
       end
@@ -87,9 +89,15 @@ module ONIX
 
       if input.kind_of?(String)
         @file   = File.open(input, "r")
-        @reader = Nokogiri::XML::Reader(@file, nil, opts[:encoding]) { |cfg| cfg.dtdload.noent }
+        @reader = Nokogiri::XML::Reader(@file, nil, opts[:encoding]) do |cfg|
+          cfg.dtdload if opts[:dtdload]
+          cfg.noent
+        end
       elsif input.kind_of?(IO)
-        @reader = Nokogiri::XML::Reader(input, nil, opts[:encoding]) { |cfg| cfg.dtdload.noent }
+        @reader = Nokogiri::XML::Reader(input, nil, opts[:encoding]) do |cfg|
+          cfg.dtdload if opts[:dtdload]
+          cfg.noent
+        end
       else
         raise ArgumentError, "Unable to read from file or IO stream"
       end


### PR DESCRIPTION
### Why is this change necessary?

The `EDItEUR` organization who owns the ONIX spec has lost their webhosting or is having a prolonged outage.  This means the official ONIX spec DTD schema files are now 504ing and causing validation errors when the schema can't be loaded.  This is currently blocking Bowker ONIX feed handling within `pulp`.

* http://www.editeur.org/onix/2.1/reference/onix-international.dtd


### How does this change address the issue?

Allow enabling/disabling `dtdload` option for ONIX XML processing with a default of `true` (enabled).

### CC

* @BookBub/partner-products-devs 