### PR TITLE
Allow for changing the encoding of the XML file in the normaliser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 pkg
 Gemfile.lock
+.DS_Store
+vendor/*
+.bundle/*

--- a/data/iso_8859_1_data.xml
+++ b/data/iso_8859_1_data.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE ONIXmessage SYSTEM "http://www.editeur.org/onix/2.1/short/onix-international.dtd">
+<ONIXmessage>
+
+<header>
+<m173>2141191</m173>
+<m174>R.R. Bowker</m174>
+<m175>Electronic Production Department, Toll Free 888-269-5372, Local 908-286-1090</m175>
+<m180>1</m180>
+<m182>20200504</m182>
+<m184>eng</m184>
+<m185>01</m185>
+<m186>USD</m186>
+<m187>in</m187>
+<m188>oz</m188>
+<m193>General trade</m193>
+</header>
+
+<product>
+<a001>GBR71341643</a001>
+<a002>03</a002>
+<a194>04</a194>
+<a197>R.R. Bowker</a197>
+<productidentifier>
+<b221>01</b221>
+<b233>Harlequin Mills &amp; Boon, Limited</b233>
+<b244>199044</b244></productidentifier>
+<productidentifier>
+<b221>02</b221>
+<b244>0008902011</b244></productidentifier>
+<productidentifier>
+<b221>03</b221>
+<b244>9780008902018</b244></productidentifier>
+<productidentifier>
+<b221>15</b221>
+<b244>9780008902018</b244></productidentifier>
+<b012>ED</b012>
+<b333>E200</b333>
+<b333>E101</b333>
+<b211>029</b211>
+<series>
+<seriesidentifier>
+<b273>01</b273>
+<b244>02008446</b244></seriesidentifier>
+<title>
+<b202>01</b202>
+<b203>Mills and Boon Medical Ser.</b203></title></series>
+<title>
+<b202>01</b202>
+<b203>Single Dad in Her Stocking / a Puppy and a Christmas Proposal</b203>
+<b029>Single Dad in Her Stocking / a Puppy and a Christmas Proposal</b029></title>
+<workidentifier>
+<b201>01</b201>
+<b233>Bowker</b233>
+<b244>65807867</b244></workidentifier>
+<contributor>
+<b034>1</b034>
+<b035>A01</b035>
+<b037>Roberts, Alison</b037>
+<b039>Alison</b039>
+<b040>Roberts</b040>
+<personnameidentifier>
+<b390>01</b390>
+<b233>Bowker</b233>
+<b244>00904141</b244></personnameidentifier>
+<personnameidentifier>
+<b390>16</b390>
+<b233>isni</b233>
+<b244>0000000044314600</b244></personnameidentifier>
+<b044>New Zealander Alison Roberts has written more than eighty romance novels for Harlequin Mills and Boon. She has also worked as a primary school teacher, a cardiology research technician and a paramedic. Currently, she is living her dream of living - and writing - in a gorgeous village in the south of France.</b044></contributor>
+<contributor>
+<b034>2</b034>
+<b035>A01</b035>
+<b037>George, Louisa</b037>
+<b039>Louisa</b039>
+<b040>George</b040>
+<personnameidentifier>
+<b390>01</b390>
+<b233>Bowker</b233>
+<b244>35065588</b244></personnameidentifier>
+<b044>Louisa George is a romance author who was selected as a finalist in the Romance Writers of America (RWA) awards which recognise excellence in published romance fiction. The award will be presented in New York in July 2015. Louisa George is a finalist in the short contemporary romance section of the RITA®, the highest international award of distinction for romance fiction. Her novel Enemies with Benefits, is one of 11 novels she has published to date with Harlequin Mills &amp; Boon, a subsidiary of HarperCollins and the world¿s largest publisher of romance fiction.</b044></contributor>
+<language>
+<b253>01</b253>
+<b252>eng</b252></language>
+<b064>FIC027020</b064>
+<b200>2011</b200>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BIC Subject Code</b171>
+<b069>FRD</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC027410</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC035000</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC027290</b069></subject>
+<b073>01</b073>
+<othertext>
+<d102>01</d102>
+<d103>02</d103>
+<d104><![CDATA[<p>Single Dad in Her Stocking<br /> <br /> A family for Christmas...and for ever?</p> <p>After losing her baby, and sacrificing her paediatric career, Emma spends every Christmas as an emergency locum. This year she's covering A&E consultant Max Cunningham - the playboy turned single dad she once shared an unforgettable kiss with...</p> <p>A Puppy and a Christmas Proposal<br /> <br /> He's giving her paws for thought!</p> <p>The last thing warm-hearted vet Beth wants this Christmas is to come face-to-face with her ex-fiancé Alex, clutching an adorable puppy! But guarding her heart from the delicious doc becomes impossible when he finally reveals why he left...</p>]]></d104>
+</othertext>
+<productwebsite>
+<f170>Publisher's URL</f170>
+<f123>http://www.millsandboon.co.uk</f123></productwebsite>
+<imprint>
+<b241>02</b241>
+<b243>1154961</b243>
+<b079>Mills &amp; Boon</b079></imprint>
+<publisher>
+<b241>02</b241>
+<b243>26149</b243>
+<b081>Harlequin Mills &amp; Boon, Limited</b081></publisher>
+<b209>London</b209>
+<b083>GB</b083>
+<b394>04</b394>
+<b003>20191128</b003>
+<salesrights>
+<b089>01</b089>
+<b090>GB IE</b090></salesrights>
+<salesrights>
+<b089>02</b089>
+<b090>AF AX AL DZ AS AD AO AI AQ AG AR AM AW AZ BS BH BD BB BY BE BZ BJ BM BT BO BA BW BV BR IO BN BG BF BI KH CM KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM VA HN HK HU IS IN ID IR IQ IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NL NC NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF PM VC WS SM ST SA SN RS SC SL SG SK SI SB SO ZA GS SS ES LK SD SR SJ SZ SE CH SY TW TJ TZ TH TL TG TK TO TT TN TR TM TC TV UG UA AE UM UY UZ VU VE VN VG VI WF EH YE ZM ZW AT CV</b090></salesrights>
+<salesrights>
+<b089>03</b089>
+<b090>US CA AU NZ</b090></salesrights>
+<supplydetail>
+<supplieridentifier>
+<j345>02</j345>
+<b233>Bowker</b233>
+<b244>00026149</b244></supplieridentifier>
+<j137>Harlequin Mills &amp; Boon, Limited</j137>
+<j272>customer.relations@hmb.co.uk</j272>
+<website>
+<b367>01</b367>
+<b295>http://www.millsandboon.co.uk</b295></website>
+<j138>GB</j138>
+<j396>20</j396>
+<j143>20191128</j143>
+<j192>02</j192></supplydetail></product>
+</ONIXmessage>

--- a/data/missing_header.xml
+++ b/data/missing_header.xml
@@ -1,0 +1,146 @@
+<!DOCTYPE ONIXmessage SYSTEM "http://www.editeur.org/onix/2.1/short/onix-international.dtd">
+<ONIXmessage>
+
+<header>
+<m173>2141191</m173>
+<m174>R.R. Bowker</m174>
+<m175>Electronic Production Department, Toll Free 888-269-5372, Local 908-286-1090</m175>
+<m180>1</m180>
+<m182>20200504</m182>
+<m184>eng</m184>
+<m185>01</m185>
+<m186>USD</m186>
+<m187>in</m187>
+<m188>oz</m188>
+<m193>General trade</m193>
+</header>
+
+<product>
+<a001>GBR71341643</a001>
+<a002>03</a002>
+<a194>04</a194>
+<a197>R.R. Bowker</a197>
+<productidentifier>
+<b221>01</b221>
+<b233>Harlequin Mills &amp; Boon, Limited</b233>
+<b244>199044</b244></productidentifier>
+<productidentifier>
+<b221>02</b221>
+<b244>0008902011</b244></productidentifier>
+<productidentifier>
+<b221>03</b221>
+<b244>9780008902018</b244></productidentifier>
+<productidentifier>
+<b221>15</b221>
+<b244>9780008902018</b244></productidentifier>
+<b012>ED</b012>
+<b333>E200</b333>
+<b333>E101</b333>
+<b211>029</b211>
+<series>
+<seriesidentifier>
+<b273>01</b273>
+<b244>02008446</b244></seriesidentifier>
+<title>
+<b202>01</b202>
+<b203>Mills and Boon Medical Ser.</b203></title></series>
+<title>
+<b202>01</b202>
+<b203>Single Dad in Her Stocking / a Puppy and a Christmas Proposal</b203>
+<b029>Single Dad in Her Stocking / a Puppy and a Christmas Proposal</b029></title>
+<workidentifier>
+<b201>01</b201>
+<b233>Bowker</b233>
+<b244>65807867</b244></workidentifier>
+<contributor>
+<b034>1</b034>
+<b035>A01</b035>
+<b037>Roberts, Alison</b037>
+<b039>Alison</b039>
+<b040>Roberts</b040>
+<personnameidentifier>
+<b390>01</b390>
+<b233>Bowker</b233>
+<b244>00904141</b244></personnameidentifier>
+<personnameidentifier>
+<b390>16</b390>
+<b233>isni</b233>
+<b244>0000000044314600</b244></personnameidentifier>
+<b044>New Zealander Alison Roberts has written more than eighty romance novels for Harlequin Mills and Boon. She has also worked as a primary school teacher, a cardiology research technician and a paramedic. Currently, she is living her dream of living - and writing - in a gorgeous village in the south of France.</b044></contributor>
+<contributor>
+<b034>2</b034>
+<b035>A01</b035>
+<b037>George, Louisa</b037>
+<b039>Louisa</b039>
+<b040>George</b040>
+<personnameidentifier>
+<b390>01</b390>
+<b233>Bowker</b233>
+<b244>35065588</b244></personnameidentifier>
+<b044>Louisa George is a romance author who was selected as a finalist in the Romance Writers of America (RWA) awards which recognise excellence in published romance fiction. The award will be presented in New York in July 2015. Louisa George is a finalist in the short contemporary romance section of the RITA®, the highest international award of distinction for romance fiction. Her novel Enemies with Benefits, is one of 11 novels she has published to date with Harlequin Mills &amp; Boon, a subsidiary of HarperCollins and the world¿s largest publisher of romance fiction.</b044></contributor>
+<language>
+<b253>01</b253>
+<b252>eng</b252></language>
+<b064>FIC027020</b064>
+<b200>2011</b200>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BIC Subject Code</b171>
+<b069>FRD</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC027410</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC035000</b069></subject>
+<subject>
+<b067>24</b067>
+<b171>Publisher-Provided BISAC Subject Code</b171>
+<b069>FIC027290</b069></subject>
+<b073>01</b073>
+<othertext>
+<d102>01</d102>
+<d103>02</d103>
+<d104><![CDATA[<p>Single Dad in Her Stocking<br /> <br /> A family for Christmas...and for ever?</p> <p>After losing her baby, and sacrificing her paediatric career, Emma spends every Christmas as an emergency locum. This year she's covering A&E consultant Max Cunningham - the playboy turned single dad she once shared an unforgettable kiss with...</p> <p>A Puppy and a Christmas Proposal<br /> <br /> He's giving her paws for thought!</p> <p>The last thing warm-hearted vet Beth wants this Christmas is to come face-to-face with her ex-fiancé Alex, clutching an adorable puppy! But guarding her heart from the delicious doc becomes impossible when he finally reveals why he left...</p>]]></d104>
+</othertext>
+<productwebsite>
+<f170>Publisher's URL</f170>
+<f123>http://www.millsandboon.co.uk</f123></productwebsite>
+<imprint>
+<b241>02</b241>
+<b243>1154961</b243>
+<b079>Mills &amp; Boon</b079></imprint>
+<publisher>
+<b241>02</b241>
+<b243>26149</b243>
+<b081>Harlequin Mills &amp; Boon, Limited</b081></publisher>
+<b209>London</b209>
+<b083>GB</b083>
+<b394>04</b394>
+<b003>20191128</b003>
+<salesrights>
+<b089>01</b089>
+<b090>GB IE</b090></salesrights>
+<salesrights>
+<b089>02</b089>
+<b090>AF AX AL DZ AS AD AO AI AQ AG AR AM AW AZ BS BH BD BB BY BE BZ BJ BM BT BO BA BW BV BR IO BN BG BF BI KH CM KY CF TD CL CN CX CC CO KM CG CD CK CR CI HR CU CY CZ DK DJ DM DO EC EG SV GQ ER EE ET FK FO FJ FI FR GF PF TF GA GM GE DE GH GI GR GL GD GP GU GT GG GN GW GY HT HM VA HN HK HU IS IN ID IR IQ IM IL IT JM JP JE JO KZ KE KI KP KR KW KG LA LV LB LS LR LY LI LT LU MO MK MG MW MY MV ML MT MH MQ MR MU YT MX FM MD MC MN ME MS MA MZ MM NA NR NP NL NC NI NE NG NU NF MP NO OM PK PW PS PA PG PY PE PH PN PL PT PR QA RE RO RU RW BL SH KN LC MF PM VC WS SM ST SA SN RS SC SL SG SK SI SB SO ZA GS SS ES LK SD SR SJ SZ SE CH SY TW TJ TZ TH TL TG TK TO TT TN TR TM TC TV UG UA AE UM UY UZ VU VE VN VG VI WF EH YE ZM ZW AT CV</b090></salesrights>
+<salesrights>
+<b089>03</b089>
+<b090>US CA AU NZ</b090></salesrights>
+<supplydetail>
+<supplieridentifier>
+<j345>02</j345>
+<b233>Bowker</b233>
+<b244>00026149</b244></supplieridentifier>
+<j137>Harlequin Mills &amp; Boon, Limited</j137>
+<j272>customer.relations@hmb.co.uk</j272>
+<website>
+<b367>01</b367>
+<b295>http://www.millsandboon.co.uk</b295></website>
+<j138>GB</j138>
+<j396>20</j396>
+<j143>20191128</j143>
+<j192>02</j192></supplydetail></product>
+</ONIXmessage>

--- a/lib/onix/normaliser.rb
+++ b/lib/onix/normaliser.rb
@@ -52,6 +52,7 @@ module ONIX
 
     def run
       # optional: adjust listed encoding
+      # has to come before the parsing for the short tags or original encoding will be used
       if @options['encoding']
         dest = next_tempfile
         force_encoding(@curfile, dest, @options['encoding'])

--- a/lib/onix/normaliser.rb
+++ b/lib/onix/normaliser.rb
@@ -51,6 +51,14 @@ module ONIX
     end
 
     def run
+      # optional: adjust listed encoding
+      if @options['encoding']
+        dest = next_tempfile
+        force_encoding(@curfile, dest, @options['encoding'])
+        FileUtils.rm_rf(@curfile)
+        @curfile = dest
+      end
+
       # remove short tags
       if @head.include?("ONIXmessage")
         dest = next_tempfile
@@ -86,6 +94,24 @@ module ONIX
         tf.close!
       end
       p
+    end
+
+    # uses the optionally passed in encoding as the assumed encoding of the XML file.
+    # for use in cases where the encoding in the file is known to be incorrect.
+    #
+    def force_encoding(src, dest, encoding)
+      inpath = File.expand_path(src)
+      outpath = File.expand_path(dest)
+
+      head = File.open(inpath,"r").read(512)
+      encoding_decl = "version=\"1.0\" encoding=\"#{encoding}\""
+
+      if head.include?("<?xml")
+        `cat #{inpath} | sed -re 's/xml[^\?]\+/xml #{encoding_decl} /' > #{outpath}`
+      else
+        `echo '<?xml #{encoding_decl} ?>' > #{outpath}`
+        `cat #{inpath} >> #{outpath}`
+      end
     end
 
     # uses an XSLT stylesheet provided by edituer to convert

--- a/spec/normaliser_spec.rb
+++ b/spec/normaliser_spec.rb
@@ -92,3 +92,26 @@ describe ONIX::Normaliser, "with a utf8 file that has illegal control chars" do
     content.include?("<TitleText>OXFORDPICTURE DICTIONARY CHINESE</TitleText>").should be_true
   end
 end
+
+describe ONIX::Normaliser, "with an iso-8859-1 file that has special chars" do
+
+  before(:each) do
+    @data_path = File.join(File.dirname(__FILE__),"..","data")
+    @filename  = File.join(@data_path, "iso_8859_1_data.xml")
+    @outfile   = @filename + ".new"
+  end
+
+  after(:each) do
+    # File.unlink(@outfile) if File.file?(@outfile)
+  end
+
+  it "should convert the file and special chars to utf-8" do
+    ONIX::Normaliser.process(@filename, @outfile)
+
+    File.file?(@outfile).should be_true
+    content = File.read(@outfile)
+
+    content.include?("<TitleText>Property Is a Girl's Best Friend</TitleText>").should be_true
+    content.include?("<PersonNameInverted>Küng, Hans</PersonNameInverted>").should be_true
+  end
+end

--- a/spec/normaliser_spec.rb
+++ b/spec/normaliser_spec.rb
@@ -93,7 +93,7 @@ describe ONIX::Normaliser, "with a utf8 file that has illegal control chars" do
   end
 end
 
-describe ONIX::Normaliser, "with an iso-8859-1 file that has special chars" do
+describe ONIX::Normaliser, "with a file with an incorrect encoding and a correct encoding provided" do
 
   before(:each) do
     @data_path = File.join(File.dirname(__FILE__),"..","data")
@@ -102,16 +102,39 @@ describe ONIX::Normaliser, "with an iso-8859-1 file that has special chars" do
   end
 
   after(:each) do
-    # File.unlink(@outfile) if File.file?(@outfile)
+    File.unlink(@outfile) if File.file?(@outfile)
   end
 
-  it "should convert the file and special chars to utf-8" do
-    ONIX::Normaliser.process(@filename, @outfile)
+  it "should treat the file as the given encoding and handle special characters" do
+    ONIX::Normaliser.process(@filename, @outfile, { encoding: 'UTF-8' })
 
     File.file?(@outfile).should be_true
     content = File.read(@outfile)
 
-    content.include?("<TitleText>Property Is a Girl's Best Friend</TitleText>").should be_true
-    content.include?("<PersonNameInverted>Küng, Hans</PersonNameInverted>").should be_true
+    content.include?("RITA®").should be_true
+    content.include?("face-to-face with her ex-fiancé").should be_true
+  end
+end
+
+describe ONIX::Normaliser, "with a file no encoding provided" do
+
+  before(:each) do
+    @data_path = File.join(File.dirname(__FILE__),"..","data")
+    @filename  = File.join(@data_path, "missing_header.xml")
+    @outfile   = @filename + ".new"
+  end
+
+  after(:each) do
+    File.unlink(@outfile) if File.file?(@outfile)
+  end
+
+  it "should treat the file as the given encoding and handle special characters" do
+    ONIX::Normaliser.process(@filename, @outfile, { encoding: 'ISO-8859-1' })
+
+    File.file?(@outfile).should be_true
+    content = File.read(@outfile)
+
+    content.include?("RITAÂ®").should be_true
+    content.include?("face-to-face with her ex-fiancÃ©").should be_true
   end
 end


### PR DESCRIPTION
We ran into a bug with Bowker raw books where strange characters were showing up in book descriptions, ex. `fiancÃ©` instead of `fiancé`.

Turns out, Bowker's XML files say that they're encoded in `ISO-8859-1`, but the characters appear to be in `UTF-8`. I confirmed this by looking at the files we're accepting from Bowker. The fact that the encoding is declared to be `ISO-8859-1` is leading to the odd characters appearing ([problem nicely described here](https://www.i18nqa.com/debug/bug-utf-8-latin1.html)) when our ONIX normalizing tries to process the file. The normalized XML files show these strange characters ([example](https://s3.console.aws.amazon.com/s3/object/bookbub-provider-data?region=us-east-1&prefix=production/bowker_daily/2020/05/04/normalized/BookBub-20200503_5_normalized_00.xml)) while the simply split files do not ([example](https://s3.console.aws.amazon.com/s3/object/bookbub-provider-data?region=us-east-1&prefix=production/bowker_daily/2020/05/04/split/BookBub-20200503_5_split_00.xml)).

We should expand our onix gem to allow us to pass in the encoding to use. If this is too complicated, we could just remove the line with the incorrect encoding and I'm pretty sure this would all work fine as well.

We'll need to pass the option for the encoding in for Bowker ingresses in Pulp, which will be a separate PR in that repo. We'll also need to do a backfill to find and fix any affected descriptions in Pulp.

cc @BookBub/data-engineering 