### PR TITLE
Update the normaliser sed command

### DIFF
--- a/data/iso_8859_1_data.xml
+++ b/data/iso_8859_1_data.xml
@@ -104,7 +104,7 @@
 <othertext>
 <d102>01</d102>
 <d103>02</d103>
-<d104><![CDATA[<p>Single Dad in Her Stocking<br /> <br /> A family for Christmas...and for ever?</p> <p>After losing her baby, and sacrificing her paediatric career, Emma spends every Christmas as an emergency locum. This year she's covering A&E consultant Max Cunningham - the playboy turned single dad she once shared an unforgettable kiss with...</p> <p>A Puppy and a Christmas Proposal<br /> <br /> He's giving her paws for thought!</p> <p>The last thing warm-hearted vet Beth wants this Christmas is to come face-to-face with her ex-fiancé Alex, clutching an adorable puppy! But guarding her heart from the delicious doc becomes impossible when he finally reveals why he left...</p>]]></d104>
+<d104><![CDATA[<p xml:lang="EN-GB">Single Dad in Her Stocking<br /> <br /> A family for Christmas...and for ever?</p> <p>After losing her baby, and sacrificing her paediatric career, Emma spends every Christmas as an emergency locum. This year she's covering A&E consultant Max Cunningham - the playboy turned single dad she once shared an unforgettable kiss with...</p> <p>A Puppy and a Christmas Proposal<br /> <br /> He's giving her paws for thought!</p> <p>The last thing warm-hearted vet Beth wants this Christmas is to come face-to-face with her ex-fiancé Alex, clutching an adorable puppy! But guarding her heart from the delicious doc becomes impossible when he finally reveals why he left...</p>]]></d104>
 </othertext>
 <productwebsite>
 <f170>Publisher's URL</f170>

--- a/lib/onix/normaliser.rb
+++ b/lib/onix/normaliser.rb
@@ -108,7 +108,7 @@ module ONIX
       encoding_decl = "version=\"1.0\" encoding=\"#{encoding}\""
 
       if head.include?("<?xml")
-        `cat #{inpath} | sed -re 's/xml[^\?]\+/xml #{encoding_decl} /' > #{outpath}`
+        `cat #{inpath} | sed -re '1s/xml[^\?]\+/xml #{encoding_decl} /;t' > #{outpath}`
       else
         `echo '<?xml #{encoding_decl} ?>' > #{outpath}`
         `cat #{inpath} >> #{outpath}`

--- a/spec/normaliser_spec.rb
+++ b/spec/normaliser_spec.rb
@@ -105,7 +105,7 @@ describe ONIX::Normaliser, "with a file with an incorrect encoding and a correct
     File.unlink(@outfile) if File.file?(@outfile)
   end
 
-  it "should treat the file as the given encoding and handle special characters" do
+  it "should treat the file as the given encoding and handle special characters and not edit any contained xml declarations" do
     ONIX::Normaliser.process(@filename, @outfile, { encoding: 'UTF-8' })
 
     File.file?(@outfile).should be_true
@@ -113,6 +113,7 @@ describe ONIX::Normaliser, "with a file with an incorrect encoding and a correct
 
     content.include?("RITA®").should be_true
     content.include?("face-to-face with her ex-fiancé").should be_true
+    content.include?('xml:lang="EN-GB"').should be_true
   end
 end
 


### PR DESCRIPTION
Turns out, XML files might have other references to xml in the body, and the sed command was overwriting those! Ack.

Updated the sed command in this PR to only update the first xml command. We know that the first one is the right one since we check for the xml declaration prior to running this bit of code, and that xml declaration has to be first!

Rollbar here: https://app.rollbar.com/a/BookBub/fix/item/Pulp/3110?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

cc @BookBub/data-engineering 