### PR TITLE
Remove has_rdoc flag from gemspec

### DIFF
--- a/onix.gemspec
+++ b/onix.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.description       = "A convient mapping between ruby objects and the ONIX XML specification"
   s.authors           = ["James Healy"]
   s.email             = ["jimmy@deefa.com"]
-  s.has_rdoc          = true
   s.homepage          = "http://github.com/yob/onix"
   s.rdoc_options     << "--title" << "ONIX - Working with the ONIX XML spec" <<
                         "--line-numbers"


### PR DESCRIPTION
The `has_rdoc` flag has been deprecated and removed in the latest version of Ruby (4.x). The flag is supposedly a way to opt in auto-documenting though it's been deprecated for years. We can remove.